### PR TITLE
Add support for custom @import modifier functions

### DIFF
--- a/PostCSS.sublime-syntax
+++ b/PostCSS.sublime-syntax
@@ -57,6 +57,14 @@ contexts:
     - include: postcss-variable-definitions
     - include: postcss-variables
 
+  at-import-body:
+    - meta_prepend: true
+    - match: (?:(?!layer|supports|url){{ident}})(?=\()
+      scope: meta.function-call.identifier.css variable.function.css
+      push:
+        - other-function-arguments-list-body
+        - function-arguments-list-begin
+
   at-other:
     - meta_prepend: true
     - include: postcss-at-apply

--- a/tests/syntax_test_scope.postcss
+++ b/tests/syntax_test_scope.postcss
@@ -25,6 +25,25 @@
 //           ^ punctuation.section.interpolation.end.postcss
 
 /*
+ * import at-rules
+ */
+
+    @import "url" prefix(tw);
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.css.postcss
+//  ^^^^^^^^^^^^^^^^^^^^^^^^ meta.at-rule.import.css
+//  ^^^^^^^ keyword.control.directive.css
+//  ^ punctuation.definition.keyword.css
+//          ^^^^^ meta.string.css string.quoted.double.css
+//          ^ punctuation.definition.string.begin.css
+//              ^ punctuation.definition.string.end.css
+//                ^^^^^^ variable.function.css
+//                      ^^^^ meta.function-call.arguments.css meta.group.css
+//                      ^ punctuation.section.group.begin.css
+//                       ^^ support.constant.property-value.css
+//                         ^ punctuation.section.group.end.css
+//                          ^ punctuation.terminator.rule.css
+
+/*
  * unknown at-rules
  */
 


### PR DESCRIPTION
Fixes #1

This commit adds patterns to scope function calls of unknown names within import at-rules, as PostCSS can add additional language features via plugins' custom parsers.